### PR TITLE
improve result by use the noise level after first iteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "rollup": "^3.22.0"
   },
   "dependencies": {
-    "cuthill-mckee": "^1.0.0"
+    "cuthill-mckee": "^1.0.0",
+    "ml-spectra-processing": "^14.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   },
   "dependencies": {
     "cuthill-mckee": "^1.0.0",
-    "ml-spectra-processing": "^14.3.0"
+    "ml-spectra-processing": "^14.5.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,4 @@
-import {
-  xAbsolute,
-  xMultiply,
-  xNoiseSanPlot,
-  xSubtract,
-  xSum,
-} from 'ml-spectra-processing';
+import { xMultiply, xNoiseSanPlot, xAbsoluteSum } from 'ml-spectra-processing';
 
 import cholesky from './choleskySolver';
 import { updateSystem, getDeltaMatrix, getCloseIndex } from './utils';
@@ -79,7 +73,6 @@ export default function airPLS(x, y, options = {}) {
     iteration < maxIterations && Math.abs(sumNegDifferences) > stopCriterion;
     iteration++
   ) {
-    console.time('baseline');
     let [leftHandSide, rightHandSide] = updateSystem(
       lowerTriangularNonZeros,
       y,
@@ -116,7 +109,6 @@ export default function airPLS(x, y, options = {}) {
 
     weights[0] = 1;
     weights[l] = 1;
-    console.timeEnd('baseline');
   }
 
   return {
@@ -139,13 +131,6 @@ export default function airPLS(x, y, options = {}) {
 }
 
 function getStopCriterion(y, tolerance) {
-  let sum = y[0];
-  for (let i = 1; i < y.length; i++) {
-    if (y[i] < 0) {
-      sum -= y[i];
-    } else {
-      sum += y[i];
-    }
-  }
+  let sum = xAbsoluteSum(y);
   return tolerance * sum;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,39 @@
-import {
-  xAbsolute,
-  xMean,
-  xMedian,
-  xNoiseSanPlot,
-  xStandardDeviation,
-} from 'ml-spectra-processing';
+import { xMultiply, xNoiseSanPlot } from 'ml-spectra-processing';
 
 import cholesky from './choleskySolver';
 import { updateSystem, getDeltaMatrix, getCloseIndex } from './utils';
+
+function getControlPoints(x, y, options = {}) {
+  const { length } = x;
+  let { controlPoints = Int8Array.from({ length }).fill(0) } = options;
+  const { zones = [], weights = Float64Array.from({ length }).fill(1) } =
+    options;
+
+  if (x.length !== y.length) {
+    throw new RangeError('Y should match the length with X');
+  } else if (controlPoints.length !== x.length) {
+    throw new RangeError('controlPoints should match the length with X');
+  } else if (weights.length !== x.length) {
+    throw new RangeError('weights should match the length with X');
+  }
+
+  zones.forEach((range) => {
+    let indexFrom = getCloseIndex(x, range.from);
+    let indexTo = getCloseIndex(x, range.to);
+    if (indexFrom > indexTo) [indexFrom, indexTo] = [indexTo, indexFrom];
+    for (let i = indexFrom; i < indexTo; i++) {
+      controlPoints[i] = 1;
+    }
+  });
+
+  return {
+    weights:
+      'controlPoints' in options || zones.length > 0
+        ? xMultiply(weights, controlPoints)
+        : weights,
+    controlPoints,
+  };
+}
 
 /**
  * Fit the baseline drift by iteratively changing weights of sum square error between the fitted baseline and original signals,
@@ -19,48 +45,26 @@ import { updateSystem, getDeltaMatrix, getCloseIndex } from './utils';
  * @param {number} [options.tolerance = 0.001] - Factor of the sum of absolute value of original data, to compute stop criterion
  * @param {Array<number>} [options.weights = [1,1,...]] - Initial weights vector, default each point has the same weight
  * @param {number} [options.lambda = 100] - Factor of weights matrix in -> [I + lambda D'D]z = x
- * @param {Array<number>} [options.controlPoints = []] - Array of x axis values to force that baseline cross those points.
+ * @param {Array<number>} [options.controlPoints = []] - Array of 0|1 to force the baseline cross those points.
  * @param {Array<number>} [options.zones = []] - Array of x axis values (as from - to), to force that baseline cross those zones.
  * @returns {{corrected: Array<number>, error: number, iteration: number, baseline: Array<number>}}
  */
 export default function airPLS(x, y, options = {}) {
-  let {
-    maxIterations = 100,
-    lambda = 10,
-    tolerance = 0.001,
-    weights = new Array(y.length).fill(0.8),
-    controlPoints = [],
-    zones = [],
-  } = options;
-  if (controlPoints.length > 0) {
-    controlPoints.forEach((e, i, arr) => (arr[i] = getCloseIndex(x, e)));
-  }
-  // if (zones.length > 0) {
-  //   zones.forEach((range) => {
-  //     let indexFrom = getCloseIndex(x, range.from);
-  //     let indexTo = getCloseIndex(x, range.to);
-  //     if (indexFrom > indexTo) [indexFrom, indexTo] = [indexTo, indexFrom];
-  //     for (let i = indexFrom; i < indexTo; i++) {
-  //       controlPoints.push(i);
-  //     }
-  //   });
-  // }
+  const { weights, controlPoints } = getControlPoints(x, y, options);
+  let { maxIterations = 100, lambda = 10, tolerance = 0.001 } = options;
 
-  for (const point of controlPoints) {
-    weights[point] = 2;
-  }
   let baseline, iteration;
-  let nbPoints = y.length;
-  let l = nbPoints - 1;
   let sumNegDifferences = Number.MAX_SAFE_INTEGER;
   let stopCriterion = tolerance * y.reduce((sum, e) => Math.abs(e) + sum, 0);
 
+  const { length } = y;
   let { lowerTriangularNonZeros, permutationEncodedArray } = getDeltaMatrix(
-    nbPoints,
+    length,
     lambda,
   );
 
   let threshold = 1;
+  const l = length - 1;
   let prevNegSum = Number.MAX_SAFE_INTEGER;
   for (
     iteration = 0;
@@ -73,7 +77,7 @@ export default function airPLS(x, y, options = {}) {
       weights,
     );
 
-    let cho = cholesky(leftHandSide, nbPoints, permutationEncodedArray);
+    let cho = cholesky(leftHandSide, length, permutationEncodedArray);
 
     baseline = cho(rightHandSide);
 
@@ -88,46 +92,25 @@ export default function airPLS(x, y, options = {}) {
         break;
       }
     }
-    console.log(
-      sumNegDifferences,
-      prevNegSum,
-      prevNegSum / sumNegDifferences,
-      stopCriterion,
-      iteration,
-    );
 
     prevNegSum = sumNegDifferences + 0;
     let maxNegativeDiff = -1 * Number.MAX_SAFE_INTEGER;
-    console.log({ threshold });
     for (let i = 1; i < l; i++) {
       let diff = difference[i];
-
-      if (iteration < 100) {
-        if (Math.abs(diff) > threshold) {
-          weights[i] = 0;
-        } else {
-          const factor = diff > 0 ? -10 : 1;
-          weights[i] = Math.exp(
-            (factor * (iteration * diff)) / Math.abs(sumNegDifferences),
-          );
-        }
-      } else if (diff > 0) {
+      if (controlPoints[i] < 1 && Math.abs(diff) > threshold) {
         weights[i] = 0;
       } else {
-        weights[i] = Math.exp((iteration * diff) / Math.abs(sumNegDifferences));
+        const factor = diff > 0 ? -1 : 1;
+        weights[i] = Math.exp(
+          (factor * (iteration * diff)) / Math.abs(sumNegDifferences),
+        );
       }
 
       if (diff < 0 && maxNegativeDiff < diff) maxNegativeDiff = diff;
     }
 
-    // let value = Math.exp(
-    //   (iteration * maxNegativeDiff) / Math.abs(sumNegDifferences),
-    // );
-    // weights[0] = 1;
-    // weights[l] = 1;
-    // for (const i of controlPoints) {
-    //   weights[i] = value;
-    // }
+    weights[0] = 1;
+    weights[l] = 1;
   }
 
   return {


### PR DESCRIPTION
Detecting baseline zones correctly
![Monosnap NMRium 2024-04-26 09-10-33](https://github.com/mljs/airpls/assets/12143935/8aa25849-1152-4053-b970-0f2939bb1ea1)

The result after only one iteration is:
![Monosnap NMRium 2024-04-26 09-11-22](https://github.com/mljs/airpls/assets/12143935/69fe0d67-5ba4-4719-8e4d-b13306a29f8a)

Without baseline detection, after seven iterations:

<img width="898" alt="image" src="https://github.com/mljs/airpls/assets/12143935/95793128-2ef4-4120-b46f-624e06a3dcd0">

The baseline is now in the middle of the noise

<img width="612" alt="image" src="https://github.com/mljs/airpls/assets/12143935/b76cfd97-a6f2-4041-a7cc-2a3cf020bdcc">

